### PR TITLE
update CNAME

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-docs.rkvst.com
+docs.datatrails.ai


### PR DESCRIPTION
the CNAME change has reverted. This changes it back to docs.datatrails.ai

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>