### PR TITLE
SCITT API Cleanup

### DIFF
--- a/content/developers/developer-patterns/scitt-api/index.md
+++ b/content/developers/developer-patterns/scitt-api/index.md
@@ -134,6 +134,7 @@ For the Quickstart, create a testing [COSE Key](https://cose-wg.github.io/cose-s
     ```
 
 1. Monitor for the Statement to be anchored. Once `"status": "succeeded"`, proceed to the next step
+
     ```shell
     curl -H @$HOME/.datatrails/bearer-token.txt \
       https://app.datatrails.ai/archivist/v1/publicscitt/operations/$OPERATION_ID \

--- a/content/developers/developer-patterns/scitt-api/index.md
+++ b/content/developers/developer-patterns/scitt-api/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Quickstart: SCITT Statements (Preview)"
 description: "Getting Started with SCITT: creating a collection of statements  (Preview)"
-lead: "Push a collection of Statements using SCITT APIs"
+lead: "How to push a collection of Statements using SCITT APIs"
 date: 2021-06-09T13:49:35+01:00
 lastmod: 2021-06-09T13:49:35+01:00
 draft: false
@@ -84,8 +84,6 @@ Clone the [DataTrails SCITT Examples](https://github.com/datatrails/datatrails-s
 If you already have a COSE Key, skip ahead to [Generating a Payload](#generating-a-payload)
 {{< /note >}}
 
-There are multiple methods to create a signed statement, for methods other than using a basic signing key, see: _(TODO: link to supporting docs)
-_<br>
 For the Quickstart, create a testing [COSE Key](https://cose-wg.github.io/cose-spec/#key-structure) which DataTrails will cryptographically validate upon registration
 
   ```bash

--- a/content/developers/developer-patterns/scitt-api/index.md
+++ b/content/developers/developer-patterns/scitt-api/index.md
@@ -62,19 +62,19 @@ Clone the [DataTrails SCITT Examples](https://github.com/datatrails/datatrails-s
 
 1. To ease copying and pasting commands, update any variables to fit your environment
 
-  ```bash
-  # your identity
-  ISSUER="sample.synsation.io"
+    ```bash
+    # your identity
+    ISSUER="sample.synsation.io"
 
-  # signing key to sign the SCITT Statements
-  SIGNING_KEY="my-signing-key.pem"
+    # signing key to sign the SCITT Statements
+    SIGNING_KEY="my-signing-key.pem"
 
-  # File representing the signed statement to be registered
-  SIGNED_STATEMENT_FILE="signed-statement.txt"
+    # File representing the signed statement to be registered
+    SIGNED_STATEMENT_FILE="signed-statement.txt"
 
-  # Feed ID, used to correlate a collection of statements about an artifact
-  FEED="my-product-id"
-  ```
+    # Feed ID, used to correlate a collection of statements about an artifact
+    FEED="my-product-id"
+    ```
 
 1. Create a [bearer_token](/developers/developer-patterns/getting-access-tokens-using-app-registrations) stored as a file, in a secure local directory with 0600 permissions.
 
@@ -94,19 +94,19 @@ For the Quickstart, create a testing [COSE Key](https://cose-wg.github.io/cose-s
 
 ## Generating a Payload
 
-In the samples we assume the statement is a json document, e.g:
+1. Create a simple json payload
 
-```bash
-cat > payload.json <<EOF
-{
-    "author": "fred",
-    "title": "my biography",
-    "reviews": "mixed"
-}
-EOF
-```
+    ```bash
+    cat > payload.json <<EOF
+    {
+        "author": "fred",
+        "title": "my biography",
+        "reviews": "mixed"
+    }
+    EOF
+    ```
 
-1. Create a Signed Statement for the SPDX SBOM
+1. Create a COSE Signed Statement for the `payload.json` file
 
     ```bash
     python scitt/create_signed_statement.py \
@@ -119,7 +119,7 @@ EOF
 
 1. Register the Statement
   {{< note >}}
-  The current DataTrails payload must be encased in a json object:
+  Note: The current DataTrails payload must be encased in a json object:
 
     `{"statement":"<COSE_SIGNED_STATEMENT>"}`
 
@@ -157,7 +157,9 @@ By querying the series of statements, consumers can verify who did what and when
       https://app.datatrails.ai/archivist/v2/publicassets/-/events?event_attributes.feed_id=$FEED | jq
     ```
 
-To filter on specific content types, such as what SBOMs have been registered, or which issuers have made statements, see \<TODO: here>
+{{< note >}}
+Coming soon: Filter on specific content types, such as what SBOMs have been registered, or which issuers have made statements.
+{{< /note >}}
 
 ## Summary
 
@@ -170,4 +172,3 @@ For more information:
 
 <!-- - [DataTrails SCITT API Reference](TBD) -->
 - [SCITT.io](SCITT.io)
-

--- a/content/developers/developer-patterns/scitt-api/index.md
+++ b/content/developers/developer-patterns/scitt-api/index.md
@@ -45,8 +45,7 @@ The Quickstart uses existing samples and scripts to focus on the SCITT APIs.
 Clone the [DataTrails SCITT Examples](https://github.com/datatrails/datatrails-scitt-samples) repository to copy those files to your environment.
 
   ```bash
-  git clone https://github.com/datatrails/datatrails-scitt-samples.git
-
+  git clone https://github.com/datatrails/datatrails-scitt-samples.git && \
   cd datatrails-scitt-samples
   ```
 
@@ -57,6 +56,7 @@ Clone the [DataTrails SCITT Examples](https://github.com/datatrails/datatrails-s
     ```bash
     python -m  venv venv && \
     source venv/bin/activate && \
+    pip install --upgrade pip && \
     pip install -r requirements.txt
     ```
 
@@ -125,6 +125,7 @@ For the Quickstart, create a testing [COSE Key](https://cose-wg.github.io/cose-s
 
   This will be updated to match the SCITT API ([SCRAPI](https://github.com/ietf-scitt/draft-birkholz-scitt-scrapi/)) in a future release.
   {{< /note >}}
+
     ```bash
     OPERATION_ID=$(curl -X POST -H @$HOME/.datatrails/bearer-token.txt \
                     -d '{"statement":"'$(cat $SIGNED_STATEMENT_FILE)'"}' \
@@ -132,17 +133,28 @@ For the Quickstart, create a testing [COSE Key](https://cose-wg.github.io/cose-s
                     | jq -r .operationID)
     ```
 
-1. Monitor for the Statement to be anchored
+1. Monitor for the Statement to be anchored. Once `"status": "succeeded"`, proceed to the next step
+    ```shell
+    curl -H @$HOME/.datatrails/bearer-token.txt \
+      https://app.datatrails.ai/archivist/v1/publicscitt/operations/$OPERATION_ID \
+      | jq
+    ```
 
-    ```bash
-    ENTRY_ID=$(python scitt/check_operation_status.py --operation-id $OPERATION_ID)
+1. Retrieve the Entry_ID for registered signed statement
+
+    ```shell
+    ENTRY_ID=$(curl -H @$HOME/.datatrails/bearer-token.txt \
+      https://app.datatrails.ai/archivist/v1/publicscitt/operations/$OPERATION_ID \
+      | jq -r .operationID)
     ```
 
 1. Retrieve a SCITT Receipt
 
     ```bash
+    
     curl -H @$HOME/.datatrails/bearer-token.txt \
-      https://app.datatrails.ai/archivist/v1/publicscitt/entries/$ENTRY_ID/receipt | jq
+      https://app.datatrails.ai/archivist/v1/publicscitt/entries/$ENTRY_ID/receipt \
+      -o receipt.cbor
     ```
 
 ## Retrieve Statements for the Artifact


### PR DESCRIPTION
~~Adds a script from [datatrails-scitt-samples](https://github.com/datatrails/datatrails-scitt-samples/) to aide in waiting for the ledger to anchor the transparent statement~~

~~Dependent upon: https://github.com/datatrails/datatrails-scitt-samples/pull/4~~

Includes other cleanup items as well for bash, vs. shell providing better color viewing in the docs, and cleanup of mediatypes, and todo links
