### PR TITLE
Updates to replace CONFIRMED with COMMITED and remove SIMPLE HASH 

### DIFF
--- a/content/developers/api-reference/assets-api/index.md
+++ b/content/developers/api-reference/assets-api/index.md
@@ -49,7 +49,6 @@ Define the asset parameters and store in `/path/to/jsonfile`:
   "behaviours": [
     "RecordEvidence"
   ],
-  "proof_mechanism": "SIMPLE_HASH",
   "public": false
 }
 ```
@@ -90,7 +89,6 @@ The response is:
   "confirmation_status": "PENDING",
   "identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
   "owner": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxX",
-  "proof_mechanism": "SIMPLE_HASH",
   "public": false,
   "tenant_identity": "tenant/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
   "tracked": "TRACKED"
@@ -141,8 +139,7 @@ Define the asset parameters and store in `/path/to/jsonfile`:
     "behaviours": [
         "Builtin",
         "RecordEvidence"
-    ],
-    "proof_mechanism":"SIMPLE_HASH"
+    ]
 }
 ```
 {{< note >}}
@@ -184,7 +181,6 @@ The response is:
     "owner": "",
     "at_time": "2023-09-27T11:32:22Z",
     "storage_integrity": "TENANT_STORAGE",
-    "proof_mechanism": "SIMPLE_HASH",
     "chain_id": "8275868384",
     "public": false,
     "tenant_identity": ""

--- a/content/developers/api-reference/assets-api/index.md
+++ b/content/developers/api-reference/assets-api/index.md
@@ -43,8 +43,6 @@ Define the asset parameters and store in `/path/to/jsonfile`:
       "arc_file_name": "somepic.jpeg",
       "arc_display_name": "Picture from yesterday",
     },
-    "arc_firmware_version": "3.2.1",
-    "arc_home_location_identity": "locations/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   },
   "behaviours": [
     "RecordEvidence"
@@ -80,8 +78,6 @@ The response is:
       "arc_file_name": "somepic.jpeg",
       "arc_display_name": "Picture from yesterday",
     },
-    "arc_firmware_version": "3.2.1",
-    "arc_home_location_identity": "locations/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   },
   "behaviours": [
     "RecordEvidence"

--- a/content/developers/api-reference/events-api/index.md
+++ b/content/developers/api-reference/events-api/index.md
@@ -85,7 +85,7 @@ The response is:
     "issuer": "job.idp.server/1234",
     "subject": "bob@job"
   },
-  "confirmation_status": "CONFIRMED",
+  "confirmation_status": "COMMITTED",
   "block_number": 12,
   "transaction_index": 5,
   "transaction_id": "0x07569"
@@ -384,7 +384,7 @@ You should see the response:
     "issuer": "job.idp.server/1234",
     "subject": "bob@job"
   },
-  "confirmation_status": "CONFIRMED",
+  "confirmation_status": "COMMITTED",
   "block_number": 12,
   "transaction_index": 5,
   "transaction_id": "0x07569"

--- a/content/developers/api-reference/iam-policies-api/index.md
+++ b/content/developers/api-reference/iam-policies-api/index.md
@@ -76,7 +76,7 @@ Define the access_policies parameters and store in `/path/to/jsonfile`:
             "behaviours": [ "RecordEvidence" ],
             "event_arc_display_type_read": ["toner_type", "toner_colour"],
             "event_arc_display_type_write": ["toner_replacement"],
-            "include_attributes": [ "arc_display_name", "arc_display_type", "arc_firmware_version" ],
+            "include_attributes": [ "arc_display_name", "arc_display_type" ],
             "subjects": [
                 "subjects/6a951b62-0a26-4c22-a886-1082297b063b",
                 "subjects/a24306e5-dc06-41ba-a7d6-2b6b3e1df48d"
@@ -126,7 +126,7 @@ The response is:
             "behaviours": [ "RecordEvidence" ],
             "event_arc_display_type_read": ["toner_type", "toner_colour"],
             "event_arc_display_type_write": ["toner_replacement"],
-            "include_attributes": [ "arc_display_name", "arc_display_type", "arc_firmware_version" ],
+            "include_attributes": [ "arc_display_name", "arc_display_type" ],
             "subjects": [
                 "subjects/6a951b62-0a26-4c22-a886-1082297b063b",
                 "subjects/a24306e5-dc06-41ba-a7d6-2b6b3e1df48d"
@@ -210,7 +210,7 @@ Each of these calls returns a list of matching IAM Access Policies records in th
                     "behaviours": [ "RecordEvidence" ],
                     "event_arc_display_type_read": ["toner_type", "toner_colour"],
                     "event_arc_display_type_write": ["toner_replacement"],
-                    "include_attributes": [ "arc_display_name", "arc_display_type", "arc_firmware_version" ],
+                    "include_attributes": [ "arc_display_name", "arc_display_type" ],
                     "subjects": [
                         "subjects/6a951b62-0a26-4c22-a886-1082297b063b",
                         "subjects/a24306e5-dc06-41ba-a7d6-2b6b3e1df48d"
@@ -234,7 +234,7 @@ Each of these calls returns a list of matching IAM Access Policies records in th
                     "behaviours": [ "RecordEvidence" ],
                     "event_arc_display_type_read": ["toner_type", "toner_colour"],
                     "event_arc_display_type_write": ["toner_replacement"],
-                    "include_attributes": [ "arc_display_name", "arc_display_type", "arc_firmware_version" ],
+                    "include_attributes": [ "arc_display_name", "arc_display_type" ],
                     "subjects": [
                         "subjects/6a951b62-0a26-4c22-a886-1082297b063b",
                         "subjects/a24306e5-dc06-41ba-a7d6-2b6b3e1df48d"
@@ -292,7 +292,7 @@ Define the Access Policy parameters to be changed and store in `/path/to/jsonfil
             "behaviours": [ "RecordEvidence" ],
             "event_arc_display_type_read": ["toner_type", "toner_colour"],
             "event_arc_display_type_write": ["toner_replacement"],
-            "include_attributes": [ "arc_display_name", "arc_display_type", "arc_firmware_version" ],
+            "include_attributes": [ "arc_display_name", "arc_display_type" ],
             "subjects": [
                 "subjects/6a951b62-0a26-4c22-a886-1082297b063b",
                 "subjects/a24306e5-dc06-41ba-a7d6-2b6b3e1df48d"
@@ -342,7 +342,7 @@ The response is:
             "behaviours": [ "RecordEvidence" ],
             "event_arc_display_type_read": ["toner_type", "toner_colour"],
             "event_arc_display_type_write": ["toner_replacement"],
-            "include_attributes": [ "arc_display_name", "arc_display_type", "arc_firmware_version" ],
+            "include_attributes": [ "arc_display_name", "arc_display_type" ],
             "subjects": [
                 "subjects/6a951b62-0a26-4c22-a886-1082297b063b",
                 "subjects/a24306e5-dc06-41ba-a7d6-2b6b3e1df48d"
@@ -402,7 +402,7 @@ Each of these calls returns a list of matching Asset records in the form:
                 "arc_display_name": "arc_primary_image",
             },
         },
-        "confirmation_status": "CONFIRMED",
+        "confirmation_status": "COMMITTED",
         "tracked": "TRACKED"
         }
     ]
@@ -447,7 +447,7 @@ Each of these calls returns a list of matching IAM `access_policies` records in 
                         "subjects/a24306e5-dc06-41ba-a7d6-2b6b3e1df48d"
                     ],
                     "behaviours": [  "RecordEvidence"  ],
-                    "include_attributes": [ "arc_display_name", "arc_display_type", "arc_firmware_version" ],
+                    "include_attributes": [ "arc_display_name", "arc_display_type" ],
                     "user_attributes": [
                         {"or": ["group:maintainers", "group:supervisors"]}
                     ]

--- a/content/developers/api-reference/public-assets-api/index.md
+++ b/content/developers/api-reference/public-assets-api/index.md
@@ -51,7 +51,7 @@ curl -H "Content-Type: application/json" https://app.datatrails.ai/archivist/v2/
     "arc_description": "This asset is public",
     "arc_display_name": "Public Asset"
   },
-  "confirmation_status": "CONFIRMED",
+  "confirmation_status": "COMMITTED",
   "tracked": "TRACKED",
   "owner": "0x5eC362570D1b52a01648997db5ed7693fc6b3978",
   "at_time": "2022-07-15T14:26:40Z",
@@ -98,7 +98,7 @@ curl -H "Content-Type: application/json" https://app.datatrails.ai/archivist/v2/
                 "display_name": "",
                 "email": ""
             },
-            "confirmation_status": "CONFIRMED",
+            "confirmation_status": "COMMITTED",
             "transaction_id": "",
             "block_number": 0,
             "transaction_index": 0,
@@ -153,7 +153,7 @@ curl -H "Content-Type: application/json" https://app.datatrails.ai/archivist/v2/
                 "display_name": "",
                 "email": ""
             },
-            "confirmation_status": "CONFIRMED",
+            "confirmation_status": "COMMITTED",
             "transaction_id": "",
             "block_number": 0,
             "transaction_index": 0,
@@ -198,7 +198,7 @@ curl -H "Content-Type: application/json" https://app.datatrails.ai/archivist/v2/
         "display_name": "",
         "email": ""
     },
-    "confirmation_status": "CONFIRMED",
+    "confirmation_status": "COMMITTED",
     "transaction_id": "",
     "block_number": 0,
     "transaction_index": 0,

--- a/content/developers/api-reference/public-assets-api/index.md
+++ b/content/developers/api-reference/public-assets-api/index.md
@@ -56,7 +56,6 @@ curl -H "Content-Type: application/json" https://app.datatrails.ai/archivist/v2/
   "owner": "0x5eC362570D1b52a01648997db5ed7693fc6b3978",
   "at_time": "2022-07-15T14:26:40Z",
   "storage_integrity": "TENANT_STORAGE",
-  "proof_mechanism": "SIMPLE_HASH",
   "chain_id": "8275868384",
   "public": true,
   "tenant_identity": "tenant/8e0b600c-8234-43e4-860c-e95bdcd695a9"

--- a/content/developers/developer-patterns/containers-as-assets/index.md
+++ b/content/developers/developer-patterns/containers-as-assets/index.md
@@ -46,7 +46,6 @@ steps:
         - arc_display_name
     behaviours: 
       - RecordEvidence
-    proof_mechanism: SIMPLE_HASH
     attributes: 
       arc_display_name: Shipping Container
       arc_display_type: Shipping Container
@@ -60,7 +59,6 @@ steps:
 cat > asset.json <<EOF
 {
   "behaviours": ["RecordEvidence"],
-  "proof_mechanism": "SIMPLE_HASH",
   "attributes": {
       "arc_display_name": "Shipping Container",
       "arc_display_type": "Shipping Container"
@@ -122,7 +120,6 @@ steps:
         - arc_display_name
     behaviours: 
       - RecordEvidence
-    proof_mechanism: SIMPLE_HASH
     attributes: 
       arc_display_name: Box-1
       arc_display_type: Box
@@ -138,7 +135,6 @@ Repeat the above a few times, editing the `arc_display_name` to add several boxe
 cat > asset-box.json <<EOF
 {
     "behaviours": ["RecordEvidence"],
-    "proof_mechanism": "SIMPLE_HASH",
     "attributes": {
         "arc_display_name": "Box-1",
         "arc_display_type": "Box",

--- a/content/developers/developer-patterns/getting-access-tokens-using-app-registrations/index.md
+++ b/content/developers/developer-patterns/getting-access-tokens-using-app-registrations/index.md
@@ -184,7 +184,6 @@ If you have existing assets, the output will be similar to:
       "owner": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
       "at_time": "2023-09-22T03:39:46Z",
       "storage_integrity": "TENANT_STORAGE",
-      "proof_mechanism": "SIMPLE_HASH",
       "chain_id": "8275868384",
       "public": false,
       "tenant_identity": "tenant/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"

--- a/content/developers/developer-patterns/getting-access-tokens-using-app-registrations/index.md
+++ b/content/developers/developer-patterns/getting-access-tokens-using-app-registrations/index.md
@@ -179,7 +179,7 @@ If you have existing assets, the output will be similar to:
         "arc_home_location_identity": "locations/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
         "height": "8'"
       },
-      "confirmation_status": "CONFIRMED",
+      "confirmation_status": "COMMITTED",
       "tracked": "TRACKED",
       "owner": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
       "at_time": "2023-09-22T03:39:46Z",

--- a/content/developers/developer-patterns/software-package-profile/index.md
+++ b/content/developers/developer-patterns/software-package-profile/index.md
@@ -66,7 +66,6 @@ steps:
         - arc_display_name
     behaviours: 
       - RecordEvidence
-    proof_mechanism: SIMPLE_HASH
     public: true
     attributes: 
       arc_display_name: Publicly Attested Asset 

--- a/content/developers/developer-patterns/verifying-with-simple-hash/index.md
+++ b/content/developers/developer-patterns/verifying-with-simple-hash/index.md
@@ -1,5 +1,5 @@
 ---
- title: "Verifying Assets and Events with Simple Hash"
+ title: "Archived: Verifying Assets and Events with Simple Hash"
  description: "Ensure Asset and Event Data Has Not Changed"
  lead: "Ensure Asset and Event Data Has Not Changed"
  date: 2021-05-18T14:52:25+01:00

--- a/content/developers/yaml-reference/assets/index.md
+++ b/content/developers/yaml-reference/assets/index.md
@@ -111,7 +111,6 @@ Response {
     "owner": "0x6ba1CA0a5f4a2aBC23412419bC0E14233E88d233",
     "at_time": "2022-11-18T16:55:44Z",
     "storage_integrity": "TENANT_STORAGE",
-    "proof_mechanism": "SIMPLE_HASH",
     "chain_id": "827586838445807967",
     "public": false,
     "tenant_identity": "tenant/<tenant-id>"

--- a/content/developers/yaml-reference/assets/index.md
+++ b/content/developers/yaml-reference/assets/index.md
@@ -27,7 +27,7 @@ Adding an `asset_label` allows your Asset to be referenced in later steps of the
 
 The `arc_namespace` (for the Asset) and the `namespace` (for the location) are used to distinguish between Assets and Locations created between runs of the story. Usually, these field values are derived from an environment variable `ARCHIVIST_NAMESPACE` (default value is namespace).
 
-The optional `confirm: true` entry means that the YAML Runner will wait for the Asset to be confirmed before moving on to the next step. This is beneficial if the Asset will be referenced in later steps.
+The optional `confirm: true` entry means that the YAML Runner will wait for the Asset to be committed before moving on to the next step. This is beneficial if the Asset will be referenced in later steps.
 
 For example:
 
@@ -106,7 +106,7 @@ Response {
         "ev_pump": "true",
         "arc_display_name": "ev pump 1"
     },
-    "confirmation_status": "CONFIRMED",
+    "confirmation_status": "COMMITTED",
     "tracked": "TRACKED",
     "owner": "0x6ba1CA0a5f4a2aBC23412419bC0E14233E88d233",
     "at_time": "2022-11-18T16:55:44Z",
@@ -136,7 +136,7 @@ steps:
 
 ## Assets Wait For Confirmed
 
-This action tells the YAML Runner to wait before proceeding to the next step until all Assets that meet your specified criteria are confirmed.
+This action tells the YAML Runner to wait before proceeding to the next step until all Assets that meet your specified criteria are confirmed/committed.
 
 ```yaml
 ---

--- a/content/developers/yaml-reference/events/index.md
+++ b/content/developers/yaml-reference/events/index.md
@@ -27,7 +27,7 @@ The `asset_label` must match the setting when the Asset was created in an earlie
 
 There are a few optional settings that can be used when creating Events. `attachments` uploads the attachment to DataTrails and the response is added to the Event before posting. `location` creates the location if it does not exist and adds it to the Event. The `sbom` setting uploads the SBOM to DataTrails and adds the response to the Event before posting.
 
-`confirm: true` tells the YAML Runner to wait for the Event to be confirmed before moving to the next step.
+`confirm: true` tells the YAML Runner to wait for the Event to be committed before moving to the next step.
 
 For example:
 
@@ -113,7 +113,7 @@ steps:
       print_response: true
       asset_label: Courts of Justice Paris Front Door
     props:
-      confirmation_status: CONFIRMED
+      confirmation_status: COMMITTED
     attrs:
       arc_display_type: open
     asset_attrs:
@@ -135,7 +135,7 @@ steps:
       print_response: true
       asset_label: Courts of Justice Paris Front Door
     props:
-      confirmation_status: CONFIRMED
+      confirmation_status: COMMITTED
     attrs:
       arc_display_type: open
     asset_attrs:

--- a/content/developers/yaml-reference/subjects/index.md
+++ b/content/developers/yaml-reference/subjects/index.md
@@ -156,7 +156,7 @@ steps:
 
 ## Subjects Wait for Confirmation
 
-This action tells the YAML Runner to wait before proceeding to the next step until all Subjects that meet your specified criteria are confirmed.
+This action tells the YAML Runner to wait before proceeding to the next step until all Subjects that meet your specified criteria are confirmed/committed.
 
 `subject_label` is required, and may be specified as the friendly name defined in a previous step or as the Subject ID of an existing subject, in the form `subjects/<subject-id>`.
 

--- a/content/platform/overview/advanced-concepts/index.md
+++ b/content/platform/overview/advanced-concepts/index.md
@@ -75,7 +75,7 @@ A simple Asset might look like this:
       "at_time": "2021-06-25T12:40:03Z",
 
       // Storage and integrity properties - managed by the system
-      "confirmation_status": "CONFIRMED",
+      "confirmation_status": "COMMITTED",
       "tracked": "TRACKED",
       "owner": "0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
       "storage_integrity": "LEDGER"

--- a/content/platform/overview/creating-an-asset/index.md
+++ b/content/platform/overview/creating-an-asset/index.md
@@ -66,8 +66,6 @@ Create an empty file, in later steps we will add the correct JSON.
 
 1. Add details to your new Asset.
 
-    The Proof Mechanism [`Simple Hash`](/platform/overview/advanced-concepts/#simple-hash) commits a batch of events as one blockchain transaction. This allows you to audit if the asset has changed during that time period.
-    Please see our [Advanced Concepts](/platform/overview/advanced-concepts/#proof-mechanisms) section for more information on the Proof Mechanism for your Asset.
 {{< tabs name="add_asset_details" >}}
 {{{< tab name="UI" >}}
 You will see an Asset Creation form, where you provide details of your new Asset:
@@ -91,7 +89,6 @@ steps:
         - arc_display_name
     behaviours: 
       - RecordEvidence
-    proof_mechanism: SIMPLE_HASH
 ```
 
 {{< /tab >}}
@@ -102,8 +99,7 @@ In the file you created earlier, begin adding metadata for your Asset:
 
 ```json
 {
-    "behaviours": ["RecordEvidence"],
-    "proof_mechanism": "SIMPLE_HASH"
+    "behaviours": ["RecordEvidence"]
 }
 ```
 
@@ -133,7 +129,6 @@ steps:
         - arc_display_name
     behaviours: 
       - RecordEvidence
-    proof_mechanism: SIMPLE_HASH
     attributes: 
       arc_display_name: My First Container 
       arc_display_type: Shipping Container
@@ -145,8 +140,7 @@ The DataTrails API uses the reserved attributes `arc_display_name` and `arc_disp
 
 ```json
 {
-    "behaviours": ["RecordEvidence"],
-    "proof_mechanism": "SIMPLE_HASH",
+    "behaviours": ["RecordEvidence"]
     "attributes": {
         "arc_display_name": "My First Container",
         "arc_display_type": "Shipping Container"
@@ -190,7 +184,6 @@ steps:
         - arc_display_name
     behaviours: 
       - RecordEvidence
-    proof_mechanism: SIMPLE_HASH
     attributes: 
       arc_display_name: My First Container 
       arc_display_type: Shipping Container
@@ -216,8 +209,7 @@ This example also adds a location to our Asset. To find out more about locations
 
 ```json
 {
-    "behaviours": ["RecordEvidence"],
-    "proof_mechanism": "SIMPLE_HASH",
+    "behaviours": ["RecordEvidence"]
     "attributes": {
         "arc_display_name": "My First Container",
         "arc_display_type": "Shipping Container",

--- a/content/platform/overview/registering-a-document-profile-asset/index.md
+++ b/content/platform/overview/registering-a-document-profile-asset/index.md
@@ -154,7 +154,6 @@ steps:
         - arc_display_name
     behaviours: 
       - RecordEvidence
-    proof_mechanism: SIMPLE_HASH
     public: true
     attributes: 
       arc_display_name: My First Document 
@@ -180,7 +179,6 @@ The DataTrails API uses the reserved attributes `arc_display_name` and `arc_disp
 
     },
     "behaviours": ["RecordEvidence"],
-    "proof_mechanism": "SIMPLE_HASH",
     "public": true
 }
 ```
@@ -221,7 +219,6 @@ steps:
         - arc_display_name
     behaviours: 
       - RecordEvidence
-    proof_mechanism: SIMPLE_HASH
     public: true
     attributes: 
       arc_display_name: My First Document 
@@ -259,7 +256,6 @@ This example also adds a location to our Asset. To find out more about locations
 
     },
     "behaviours": ["RecordEvidence"],
-    "proof_mechanism": "SIMPLE_HASH",
     "public": true
 }
 ```


### PR DESCRIPTION
The API examples have been updated to:
change CONFIRMED to COMMITTED
remove the SIMPLE_HASH proof mechanism
remove arc_firmware_version and some examples of arc_home_location_identity

SIMPLE HASH has been de-emphasized in the docs.