### PR TITLE
Wait for COMMITTED status before recording an Event

### DIFF
--- a/content/developers/api-reference/events-api/index.md
+++ b/content/developers/api-reference/events-api/index.md
@@ -24,6 +24,14 @@ Additional YAML examples can be found in the articles in the [Overview](/platfor
 
 Create the [bearer_token](/developers/developer-patterns/getting-access-tokens-using-app-registrations) and store in a file in a secure local directory with 0600 permissions.
 
+{{< note >}}
+**Note:** You will need to create an Asset and wait for it to reach COMMITTED state before attempting to record an Event against that Asset. If you do not do this the API call will respond with an error.
+
+One solution is to make a GET API call against the Asset ID and check that the confirmation_status field is COMMITTED, CONFIRMED of UNEQUIVOCAL before making the call to record the Event.
+
+Another is to parse the Event API call for **400 Bad Request** errors (optionally also check for **429 Too Many Requests** errors) and then retry the call after a few seconds.
+{{< /note >}}
+
 ### Event Creation
 
 Define the Event parameters and store in `/path/to/jsonfile`:
@@ -474,6 +482,27 @@ curl -g -v -X GET \
 ```
 
 Returns all Events which do not have `arc_display_type` or in which `arc_display_type` is empty.
+
+#### Fetch Events by Minimum Confirmation Status
+
+To fetch all Events with a specified confirmation status or higher, `GET` the Events resource and filter on `minimum_trust`.
+For example:
+
+```bash
+curl -g -v -X GET \
+     -H "@$HOME/.datatrails/bearer-token.txt" \
+     "https://app.datatrails.ai/archivist/v2/assets/-/events?minimum_trust=COMMITTED"
+```
+
+Returns all Events which have a `confirmation_status` level of COMMITTED, CONFIRMED or UNEQUIVOCAL. 
+
+```bash
+curl -g -v -X GET \
+     -H "@$HOME/.datatrails/bearer-token.txt" \
+     "https://app.datatrails.ai/archivist/v2/assets/-/events?minimum_trust=CONFIRMED"
+```
+
+Returns all Events which have a `confirmation_status` level of CONFIRMED or UNEQUIVOCAL. 
 
 ## Events OpenAPI Docs
 

--- a/content/platform/overview/creating-an-event-against-an-asset/index.md
+++ b/content/platform/overview/creating-an-event-against-an-asset/index.md
@@ -23,7 +23,7 @@ Asset Creation is the first Event. The more Events recorded against an Asset, th
 Events track key moments of an Asset's lifecycle; details of Who Did What When to an Asset.
 
 {{< note >}}
-Before creating an Event, follow [this guide](/platform/overview/creating-an-asset/) to create your first Asset.
+**Note:** Before creating an Event, follow [this guide](/platform/overview/creating-an-asset/) to create your first Asset. You will need to wait for the Asset to reach COMMITTED state before attempting to record an Event.
 {{< /note >}}
 
 ## Creating Events

--- a/content/platform/overview/registering-a-document-profile-asset/index.md
+++ b/content/platform/overview/registering-a-document-profile-asset/index.md
@@ -20,7 +20,7 @@ As it builds on the standard DataTrails asset the same processes are used for [P
 The following steps will guide you in creating your first Document Profile Asset.
 
 {{< note >}}
-Check out our [Core Concepts](/platform/overview/core-concepts/#assets) for more general information on Assets and [Document Profile](/developers/developer-patterns/document-profile/) for details of the Document Profile asset and event attributes.
+**Note:** Check out our [Core Concepts](/platform/overview/core-concepts/#assets) for more general information on Assets and [Document Profile](/developers/developer-patterns/document-profile/) for details of the Document Profile asset and event attributes.
 {{< /note >}}
 
 ## Registering a Document

--- a/content/platform/overview/registering-an-event-against-a-document-profile-asset/index.md
+++ b/content/platform/overview/registering-an-event-against-a-document-profile-asset/index.md
@@ -26,7 +26,7 @@ When the document version is no longer to be used there is a Withdraw Event.
 These Events track key moments of an Document's lifecycle; details of Who Did What When to each version of the document.
 
 {{< note >}}
-**Note:** Before registering an Event, follow [this guide](/platform/overview/registering-a-document-profile-asset/) to register your first Document Asset.
+**Note:** Before registering an Event, follow [this guide](/platform/overview/registering-a-document-profile-asset/) to register your first Document Asset. You will need to wait for the Asset to reach COMMITTED state before attempting to record an Event.
 {{< /note >}}
 
 ## Registering Events


### PR DESCRIPTION
Added notes about waiting for an Asset to be committed before recording an Event. 

Also documented the minimum_trust filter in the Events API reference page.