### PR TITLE
API REF: how to update an Asset attribute

### DIFF
--- a/content/developers/api-reference/assets-api/index.md
+++ b/content/developers/api-reference/assets-api/index.md
@@ -34,19 +34,20 @@ Define the asset parameters and store in `/path/to/jsonfile`:
 
 ```json
 {
+  "behaviours": ["RecordEvidence"],
   "attributes": {
     "picture_from_yesterday": {
       "arc_attribute_type": "arc_attachment",
       "arc_blob_hash_value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
       "arc_blob_identity": "blobs/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
       "arc_blob_hash_alg": "SHA256",
-      "arc_file_name": "somepic.jpeg",
+      "arc_file_name": "cat.jpeg",
       "arc_display_name": "Picture from yesterday",
     },
+    "arc_display_name": "My Cat",
+    "arc_display_type": "Cat",
+    "weight": "3.6kg"
   },
-  "behaviours": [
-    "RecordEvidence"
-  ],
   "public": false
 }
 ```
@@ -68,28 +69,104 @@ The response is:
 
 ```json
 {
-  "at_time": "2019-11-27T14:44:19Z",
-  "attributes": {
-    "picture_from_yesterday": {
-      "arc_attribute_type": "arc_attachment",
-      "arc_blob_hash_value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-      "arc_blob_identity": "blobs/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-      "arc_blob_hash_alg": "SHA256",
-      "arc_file_name": "somepic.jpeg",
-      "arc_display_name": "Picture from yesterday",
-    },
-  },
-  "behaviours": [
-    "RecordEvidence"
-  ],
-  "confirmation_status": "PENDING",
   "identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-  "owner": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxX",
-  "public": false,
-  "tenant_identity": "tenant/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-  "tracked": "TRACKED"
-}
+    "behaviours": ["RecordEvidence"],
+    "attributes": {
+        "arc_display_type": "Cat",
+        "weight": "3.6kg",
+        "picture_from_yesterday": {
+            "arc_blob_hash_alg": "SHA256",
+            "arc_file_name": "cat.jpeg",
+            "arc_display_name": "Picture from yesterday",
+            "arc_attribute_type": "arc_attachment",
+            "arc_blob_hash_value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "arc_blob_identity": "blobs/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        },
+        "arc_display_name": "My Cat"
+    },
+    "confirmation_status": "COMMITTED",
+    "tracked": "TRACKED",
+    "owner": "",
+    "at_time": "2024-05-30T12:26:37Z",
+    "proof_mechanism": "MERKLE_LOG",
+    "chain_id": "8275868384",
+    "public": false,
+    "tenant_identity": ""
+}    
+  ```
+#### Updating an Asset Attribute
+
+To update an Asset attribute, record an Event and enter the new value. Here we will update the weight of the cat from the previous example.
+
+See the [Events API reference](https://docs.datatrails.ai/developers/api-reference/events-api/) for more information about Events.
+
+```json
+{
+    "operation": "Record",
+    "behaviour": "RecordEvidence",
+    "event_attributes": {
+       "arc_display_type": "groom",
+       "additional_checks": "weigh the cat"
+    },
+    "asset_attributes": {   
+       "weight": "3.5kg"
+    },
+    "public": false
+}    
 ```
+POST the Event to update the Asset:
+
+```bash
+curl -v -X POST \
+    -H "@$HOME/.datatrails/bearer-token.txt" \
+    -H "Content-type: application/json" \
+    -d "@/path/to/jsonfile" \
+    https://app.datatrails.ai/archivist/v2/assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/events
+```
+
+The response is:
+
+```json
+{
+    "identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/events/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "asset_identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "event_attributes": {
+        "arc_display_type": "groom",
+        "additional_checks": "weigh the cat"
+    },
+    "asset_attributes": {
+        "weight": "3.5kg"
+    },
+    "operation": "Record",
+    "behaviour": "RecordEvidence",
+    "timestamp_declared": "2024-05-30T12:28:50Z",
+    "timestamp_accepted": "2024-05-30T12:28:50Z",
+    "timestamp_committed": "1970-01-01T00:00:00Z",
+    "principal_declared": {
+        "issuer": "https://app.datatrails.ai/appidpv1",
+        "subject": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        "display_name": "Custom Integration",
+        "email": ""
+    },
+    "principal_accepted": {
+        "issuer": "https://app.datatrails.ai/appidpv1",
+        "subject": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        "display_name": "Custom Integration",
+        "email": ""
+    },
+    "confirmation_status": "PENDING",
+    "transaction_id": "",
+    "block_number": 0,
+    "transaction_index": 0,
+    "from": "",
+    "tenant_identity": "",
+    "merklelog_entry": {
+        "commit": null,
+        "confirm": null,
+        "unequivocal": null
+    }
+}    
+  ```
 
 #### Creating a Public Asset
 

--- a/content/developers/api-reference/events-api/index.md
+++ b/content/developers/api-reference/events-api/index.md
@@ -99,6 +99,77 @@ The response is:
   "transaction_id": "0x07569"
 }
 ```
+### Updating an Asset Attribute
+
+To update an Asset attribute, record an Event and enter the new value. Here we will update the weight of the cat Asset created in the [Assets API reference](https://docs.datatrails.ai/developers/api-reference/assets-api/#asset-record-creation) example.
+
+```json
+{
+    "operation": "Record",
+    "behaviour": "RecordEvidence",
+    "event_attributes": {
+       "arc_display_type": "groom",
+       "additional_checks": "weigh the cat"
+    },
+    "asset_attributes": {   
+       "weight": "3.5kg"
+    },
+    "public": false
+}    
+```
+POST the Event to update the Asset:
+
+```bash
+curl -v -X POST \
+    -H "@$HOME/.datatrails/bearer-token.txt" \
+    -H "Content-type: application/json" \
+    -d "@/path/to/jsonfile" \
+    https://app.datatrails.ai/archivist/v2/assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/events
+```
+
+The response is:
+
+```json
+{
+    "identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/events/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "asset_identity": "assets/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "event_attributes": {
+        "arc_display_type": "groom",
+        "additional_checks": "weigh the cat"
+    },
+    "asset_attributes": {
+        "weight": "3.5kg"
+    },
+    "operation": "Record",
+    "behaviour": "RecordEvidence",
+    "timestamp_declared": "2024-05-30T12:28:50Z",
+    "timestamp_accepted": "2024-05-30T12:28:50Z",
+    "timestamp_committed": "1970-01-01T00:00:00Z",
+    "principal_declared": {
+        "issuer": "https://app.datatrails.ai/appidpv1",
+        "subject": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        "display_name": "Custom Integration",
+        "email": ""
+    },
+    "principal_accepted": {
+        "issuer": "https://app.datatrails.ai/appidpv1",
+        "subject": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        "display_name": "Custom Integration",
+        "email": ""
+    },
+    "confirmation_status": "PENDING",
+    "transaction_id": "",
+    "block_number": 0,
+    "transaction_index": 0,
+    "from": "",
+    "tenant_identity": "",
+    "merklelog_entry": {
+        "commit": null,
+        "confirm": null,
+        "unequivocal": null
+    }
+}    
+  ```
 
 ### Document Profile Event Creation
 


### PR DESCRIPTION
Added a JSON example for updating an Asset attribute value to the Assets and Events API reference pages.