### PR TITLE
add note on role stripping behaviour

### DIFF
--- a/content/developers/api-reference/members-api/index.md
+++ b/content/developers/api-reference/members-api/index.md
@@ -81,6 +81,10 @@ curl -v -X POST \
     https://app.datatrails.ai/archivist/iam/v1/{member_identity}:activate
 ```
 
+{{< note >}}
+User roles are stripped when a user is deactivated, so upon reactivation the user will only have basic user rights. If required once reactivated, follow the steps above to promote this user to 'Owner' role.
+{{< /note >}}
+
 ## Members OpenAPI Docs
 
 {{< openapi url="https://raw.githubusercontent.com/datatrails/datatrails-openapi/master/doc/membersv1.swagger.json" >}}<br>


### PR DESCRIPTION
Explains the role stripping behavior when deactivating a user, and how to remediate this after re-activation.

![image](https://github.com/user-attachments/assets/af4e9538-5e48-4597-a4ec-3c401a01b3c7)


re [AB#10036](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/10036)