### PR TITLE
feat: updates for cbor all the things

### DIFF
--- a/content/developers/developer-patterns/scitt-api/index.md
+++ b/content/developers/developer-patterns/scitt-api/index.md
@@ -149,12 +149,14 @@ python3 -m datatrails_scitt_samples.scripts.create_hashed_signed_statement \
 ## Register the SCITT Signed Statement on DataTrails
 
 1. Submit the Signed Statement to DataTrails, using the credentials in the `DATATRAILS_CLIENT_ID` and `DATATRAILS_CLIENT_SECRET`.
+   The `LEAF` is captured on a successful execution for verification.
 
     ```bash
-    python3 -m datatrails_scitt_samples.scripts.register_signed_statement \
-      --signed-statement-file $SIGNED_STATEMENT_FILE \
-      --output-file $TRANSPARENT_STATEMENT_FILE \
-      --log-level INFO
+    RESPONSE=$(python3 -m datatrails_scitt_samples.scripts.register_signed_statement \
+          --signed-statement-file $SIGNED_STATEMENT_FILE \
+          --output-file $TRANSPARENT_STATEMENT_FILE \
+          --log-level INFO)
+    echo $RESPONSE
     ```
 
     The last line of the output will include the leaf entry that commits the statement to the merkle log.
@@ -179,14 +181,30 @@ python3 -m datatrails_scitt_samples.scripts.create_hashed_signed_statement \
     ```bash
     python3 -m datatrails_scitt_samples.scripts.verify_receipt \
       --transparent-statement-file $TRANSPARENT_STATEMENT_FILE \
-      --leaf $LEAF
+      --leaf $(jq -r .leaf <<<"$RESPONSE")
     ```
 
-    Following the example above, $LEAF should be:
+    The verification should pass with:
 
     ```output
-    30f5650fbe3355ca892094a3fbe88e5fa3a9ae47fe3d0bbace348181eb2b76db
+    verification passed
     ```
+
+1. Simulate a failed verification, by altering the `.leaf` value
+
+    ```bash
+
+    python3 -m datatrails_scitt_samples.scripts.verify_receipt \
+      --transparent-statement-file $TRANSPARENT_STATEMENT_FILE \
+      --leaf $(jq -r .leaf <<<"$RESPONSE")"-foo"
+    ```
+
+    The verification should fail with:
+
+    ```output
+    ERROR:verify-receipt:failed to parse leaf hash
+    ```
+
 
 ## Retrieve Statements for the Artifact
 

--- a/content/developers/developer-patterns/scitt-api/index.md
+++ b/content/developers/developer-patterns/scitt-api/index.md
@@ -85,8 +85,9 @@ Clone the [DataTrails SCITT Examples](https://github.com/datatrails/datatrails-s
     # Property used to correlate a collection of statements about an artifact
     SUBJECT="my-product-id"
 
-    # File to store the verifiable event data in
-    VERIFIABLE_EVENT_FILE="event.json"
+    # A command which produces a hash, eg sha256sum on linux, or shasum on macos
+    # The specific algorithm is not important for these examples
+    HASH_COMMAND=sha256sum
     ```
 
 ## Create a Signing Key
@@ -122,7 +123,7 @@ EOF
 Create metadata with a dictionary of `key:value` pairs.
 
 ```bash
-HASH=$(shasum "payload.json" | cut -d ' ' -f 1)
+HASH=$($HASH_COMMAND "payload.json" | cut -d ' ' -f 1)
 cat > metadata.json <<EOF
 {
   "payload_hash": "$HASH",
@@ -176,16 +177,20 @@ python -m datatrails_scitt_samples.scripts.create_hashed_signed_statement \
       --log-level INFO
     ```
 
-    Find and copy the leaf hash from the output. It will look like this:
+    The last line of the output will include the leaf entry that commits the statement to the merkle log.
+    It will look like
     ```
-    INFO:register-statement:Leaf Hash: 30f5650fbe3355ca892094a3fbe88e5fa3a9ae47fe3d0bbace348181eb2b76db
+    {"entryid": "assets_b9d32c32-8ab3-4b59-8de8-bd6393167450_events_7dd2a825-495e-4fc9-b572-5872a268c8a9",
+     "leaf": "30f5650fbe3355ca892094a3fbe88e5fa3a9ae47fe3d0bbace348181eb2b76db"}
     ```
+
+    Add the `--log-level DEBUG` flag to help diagnose any issues.
 
 1. View the Transparent Statement, as a result of registering the Signed Statement
 
     ```bash
     python -m datatrails_scitt_samples.dump_cbor \
-      --input transparent-statement.cbor
+      --input $TRANSPARENT_STATEMENT_FILE
     ```
 
 1. Verify the the receipt

--- a/content/developers/developer-patterns/scitt-api/index.md
+++ b/content/developers/developer-patterns/scitt-api/index.md
@@ -187,23 +187,29 @@ python3 -m datatrails_scitt_samples.scripts.create_hashed_signed_statement \
     The verification should pass with:
 
     ```output
-    verification passed
+    verification succeeded
     ```
 
 1. Simulate a failed verification, by altering the `.leaf` value
+
+    As all entries in a log are unique, if you use the leaf value from the example above verbatim, it will *fail* to verify
 
     ```bash
 
     python3 -m datatrails_scitt_samples.scripts.verify_receipt \
       --transparent-statement-file $TRANSPARENT_STATEMENT_FILE \
-      --leaf $(jq -r .leaf <<<"$RESPONSE")"-foo"
+      --leaf "30f5650fbe3355ca892094a3fbe88e5fa3a9ae47fe3d0bbace348181eb2b76db"
     ```
 
     The verification should fail with:
 
     ```output
-    ERROR:verify-receipt:failed to parse leaf hash
+    verification failed
     ```
+
+    A more representative example, which includes computing the leaf hash from the event details, can be found in the [tests for the verification script](https://github.com/datatrails/datatrails-scitt-samples/blob/main/tests/test_verify_receipt.py#L52)
+
+
 
 ## Retrieve Statements for the Artifact
 

--- a/content/developers/developer-patterns/scitt-api/index.md
+++ b/content/developers/developer-patterns/scitt-api/index.md
@@ -84,17 +84,7 @@ Clone the [DataTrails SCITT Examples](https://github.com/datatrails/datatrails-s
 
     # Property used to correlate a collection of statements about an artifact
     SUBJECT="my-product-id"
-
-    # A command which produces a hash, eg sha256sum on linux, or shasum on macos
-    # The specific algorithm is not important for these examples
-    HASH_COMMAND=sha256sum
     ```
-
-{{< note >}}
-These defaults will place files in your current working directory.
-For session persistence, consider replacing the file paths with absolute paths.
-For example `SIGNING_KEY="$HOME/.datatrails/my-signing-key.pem"`
-{{< /note >}}
 
 ## Create a Signing Key
 
@@ -129,10 +119,8 @@ EOF
 Create metadata with a dictionary of `key:value` pairs.
 
 ```bash
-HASH=$($HASH_COMMAND "payload.json" | cut -d ' ' -f 1)
 cat > metadata.json <<EOF
 {
-  "payload_hash": "$HASH",
   "timestamp_declared": "2024-11-01T12:24:42.012345",
   "sample_version": "0.1.1",
   "project": 25,
@@ -145,20 +133,6 @@ EOF
 
 Create a COSE Signed Statement, hashing the content of the `payload.json` file.
 The payload may already be stored in another storage/package manager, which can be referenced with the `--location-hint` parameter.
-
-<!-- 
-```bash
-python3 ${SCRIPTS}create_signed_statement.py \
-  --content-type "application/json" \
-  --issuer $ISSUER \
-  --metadata-file "metadata.json" \
-  --output-file $SIGNED_STATEMENT_FILE \
-  --payload-file payload.json \
-  --payload-location "https://storage.example/$SUBJECT" \
-  --signing-key-file $SIGNING_KEY \
-  --subject $SUBJECT
-```
--->
 
 ```bash
 python3 -m datatrails_scitt_samples.scripts.create_hashed_signed_statement \
@@ -185,14 +159,13 @@ python3 -m datatrails_scitt_samples.scripts.create_hashed_signed_statement \
 
     The last line of the output will include the leaf entry that commits the statement to the merkle log.
     It will look like
-    ```
+
+    ```json
     {
       "entryid": "assets_b9d32c32-8ab3-4b59-8de8-bd6393167450_events_7dd2a825-495e-4fc9-b572-5872a268c8a9",
       "leaf": "30f5650fbe3355ca892094a3fbe88e5fa3a9ae47fe3d0bbace348181eb2b76db"
      }
     ```
-
-    Add the `--log-level DEBUG` flag to help diagnose any issues.
 
 1. View the Transparent Statement, as a result of registering the Signed Statement
 
@@ -214,7 +187,6 @@ python3 -m datatrails_scitt_samples.scripts.create_hashed_signed_statement \
     ```output
     30f5650fbe3355ca892094a3fbe88e5fa3a9ae47fe3d0bbace348181eb2b76db
     ```
-
 
 ## Retrieve Statements for the Artifact
 

--- a/content/developers/developer-patterns/scitt-api/index.md
+++ b/content/developers/developer-patterns/scitt-api/index.md
@@ -54,7 +54,7 @@ Clone the [DataTrails SCITT Examples](https://github.com/datatrails/datatrails-s
 1. Create a Python Virtual Environment for the sample scripts and install the dependencies
 
     ```bash
-    python -m venv venv && \
+    python3 -m venv venv && \
     source venv/bin/activate && \
     trap deactivate EXIT && \
     pip install --upgrade pip && \
@@ -89,6 +89,11 @@ Clone the [DataTrails SCITT Examples](https://github.com/datatrails/datatrails-s
     # The specific algorithm is not important for these examples
     HASH_COMMAND=sha256sum
     ```
+
+{{< note >}}
+These defaults will place files in your current working directory. Consider replacing the file paths with absoloute paths to your platforms temporary location. Eg `SIGNING_KEY="/tmp/my-signing-key.pem"`
+{{< /note >}}
+
 
 ## Create a Signing Key
 
@@ -142,7 +147,7 @@ The payload may already be stored in another storage/package manager, which can 
 
 <!-- 
 ```bash
-python ${SCRIPTS}create_signed_statement.py \
+python3 ${SCRIPTS}create_signed_statement.py \
   --content-type "application/json" \
   --issuer $ISSUER \
   --metadata-file "metadata.json" \
@@ -155,7 +160,7 @@ python ${SCRIPTS}create_signed_statement.py \
 -->
 
 ```bash
-python -m datatrails_scitt_samples.scripts.create_hashed_signed_statement \
+python3 -m datatrails_scitt_samples.scripts.create_hashed_signed_statement \
   --content-type "application/json" \
   --issuer $ISSUER \
   --metadata-file "metadata.json" \
@@ -171,8 +176,8 @@ python -m datatrails_scitt_samples.scripts.create_hashed_signed_statement \
 1. Submit the Signed Statement to DataTrails, using the credentials in the `DATATRAILS_CLIENT_ID` and `DATATRAILS_CLIENT_SECRET`.
 
     ```bash
-    python -m datatrails_scitt_samples.scripts.register_signed_statement \
-      --signed-statement-file signed-statement.cbor \
+    python3 -m datatrails_scitt_samples.scripts.register_signed_statement \
+      --signed-statement-file $SIGNED_STATEMENT_FILE \
       --output-file $TRANSPARENT_STATEMENT_FILE \
       --log-level INFO
     ```
@@ -189,14 +194,14 @@ python -m datatrails_scitt_samples.scripts.create_hashed_signed_statement \
 1. View the Transparent Statement, as a result of registering the Signed Statement
 
     ```bash
-    python -m datatrails_scitt_samples.dump_cbor \
+    python3 -m datatrails_scitt_samples.dump_cbor \
       --input $TRANSPARENT_STATEMENT_FILE
     ```
 
 1. Verify the the receipt
 
     ```bash
-    python -m datatrails_scitt_samples.scripts.verify_receipt \
+    python3 -m datatrails_scitt_samples.scripts.verify_receipt \
       --transparent-statement-file $TRANSPARENT_STATEMENT_FILE \
       --leaf $LEAF
     ```

--- a/content/developers/developer-patterns/scitt-api/index.md
+++ b/content/developers/developer-patterns/scitt-api/index.md
@@ -205,7 +205,6 @@ python3 -m datatrails_scitt_samples.scripts.create_hashed_signed_statement \
     ERROR:verify-receipt:failed to parse leaf hash
     ```
 
-
 ## Retrieve Statements for the Artifact
 
 The power of SCITT is the ability to retrieve the history of statements made for a given artifact.

--- a/content/developers/developer-patterns/scitt-api/index.md
+++ b/content/developers/developer-patterns/scitt-api/index.md
@@ -224,7 +224,8 @@ By querying the series of statements, consumers can verify who did what and when
     The events are listed starting with the most recently added.
 
 {{< note >}}
-Coming soon: Filter on specific values, conveyed in the protected header. For example content types, such as what SBOMs have been registered, which issuers have made statements, or custom key value pairs.
+Coming soon: Filter on specific values conveyed in the protected header.
+For example, content types, such as what SBOMs have been registered, which issuers have made statements or custom key-value pairs.
 {{< /note >}}
 
 ## Summary

--- a/content/developers/developer-patterns/scitt-api/index.md
+++ b/content/developers/developer-patterns/scitt-api/index.md
@@ -224,7 +224,7 @@ By querying the series of statements, consumers can verify who did what and when
 1. Query DataTrails for the collection of statements
 
     ```bash
-    PARAMS="event_attributes.subject=${SUBJECT}&page_size=1"
+    PARAMS="event_attributes.subject=${SUBJECT}&page_size=3"
     curl "https://app.datatrails.ai/archivist/v2/publicassets/-/events?${PARAMS}" \
       | jq
     ```

--- a/content/developers/developer-patterns/scitt-api/index.md
+++ b/content/developers/developer-patterns/scitt-api/index.md
@@ -94,7 +94,6 @@ Clone the [DataTrails SCITT Examples](https://github.com/datatrails/datatrails-s
 These defaults will place files in your current working directory. For session persistence, consider replacing the file paths with absolute paths. For example `SIGNING_KEY="$HOME/.datatrails/my-signing-key.pem"`
 {{< /note >}}
 
-
 ## Create a Signing Key
 
 {{< note >}}

--- a/content/developers/developer-patterns/scitt-api/index.md
+++ b/content/developers/developer-patterns/scitt-api/index.md
@@ -186,8 +186,10 @@ python3 -m datatrails_scitt_samples.scripts.create_hashed_signed_statement \
     The last line of the output will include the leaf entry that commits the statement to the merkle log.
     It will look like
     ```
-    {"entryid": "assets_b9d32c32-8ab3-4b59-8de8-bd6393167450_events_7dd2a825-495e-4fc9-b572-5872a268c8a9",
-     "leaf": "30f5650fbe3355ca892094a3fbe88e5fa3a9ae47fe3d0bbace348181eb2b76db"}
+    {
+      "entryid": "assets_b9d32c32-8ab3-4b59-8de8-bd6393167450_events_7dd2a825-495e-4fc9-b572-5872a268c8a9",
+      "leaf": "30f5650fbe3355ca892094a3fbe88e5fa3a9ae47fe3d0bbace348181eb2b76db"
+     }
     ```
 
     Add the `--log-level DEBUG` flag to help diagnose any issues.

--- a/content/developers/developer-patterns/scitt-api/index.md
+++ b/content/developers/developer-patterns/scitt-api/index.md
@@ -207,8 +207,12 @@ python3 -m datatrails_scitt_samples.scripts.create_hashed_signed_statement \
       --leaf $LEAF
     ```
 
-    Following the example above $LEAF should be:
-    `30f5650fbe3355ca892094a3fbe88e5fa3a9ae47fe3d0bbace348181eb2b76db`
+    Following the example above, $LEAF should be:
+
+    ```output
+    30f5650fbe3355ca892094a3fbe88e5fa3a9ae47fe3d0bbace348181eb2b76db
+    ```
+
 
 ## Retrieve Statements for the Artifact
 

--- a/content/developers/developer-patterns/scitt-api/index.md
+++ b/content/developers/developer-patterns/scitt-api/index.md
@@ -91,7 +91,9 @@ Clone the [DataTrails SCITT Examples](https://github.com/datatrails/datatrails-s
     ```
 
 {{< note >}}
-These defaults will place files in your current working directory. For session persistence, consider replacing the file paths with absolute paths. For example `SIGNING_KEY="$HOME/.datatrails/my-signing-key.pem"`
+These defaults will place files in your current working directory.
+For session persistence, consider replacing the file paths with absolute paths.
+For example `SIGNING_KEY="$HOME/.datatrails/my-signing-key.pem"`
 {{< /note >}}
 
 ## Create a Signing Key

--- a/content/developers/developer-patterns/scitt-api/index.md
+++ b/content/developers/developer-patterns/scitt-api/index.md
@@ -91,7 +91,7 @@ Clone the [DataTrails SCITT Examples](https://github.com/datatrails/datatrails-s
     ```
 
 {{< note >}}
-These defaults will place files in your current working directory. Consider replacing the file paths with absoloute paths to your platforms temporary location. Eg `SIGNING_KEY="/tmp/my-signing-key.pem"`
+These defaults will place files in your current working directory. For session persistence, consider replacing the file paths with absolute paths. For example `SIGNING_KEY="$HOME/.datatrails/my-signing-key.pem"`
 {{< /note >}}
 
 


### PR DESCRIPTION
* remove use of /tmp in favour of current working directory. tmp breaks the examples for macos
* note that indexing and retrieval for the meta map is a future release thing.
* describe how to capture the leaf hash from registration so verification can be accomplished directly
* purposefuly don't get into the details of computing the leaf hash
* remove use of `${SCRIPTS}` in favour of `python -m` which works on all platforms